### PR TITLE
Initial Builtin Support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -147,13 +147,26 @@
 134    - restore constantMap back to state
 135    - remove state from where relevant
 136 - make Interpreter artifact specific (i.e. move version, artifact and infer to it)
+137 - add polymorphism
+138 - add valueTypeOf
+139 - check arg types on fun call/ret
+140 - add array push builtin
+141 - add option to take implicit this argument to builtinFunction
+142 - Hit a bug around polymorphism and implicit casts. Implicit casts may involve copies (memory string literal -> storage). The correct order of operations is:
+143    - get concrete builtin type
+144    - assign args to go through casting/copy logic
+145 - test push
+146 - cleanup builtins - make them take their own scope with only other builtins
+147 - add pop
+148 - add concretize tests
+149 - add union tests
+150 - test pop
+
+- check that normal internal calls handle arguments/returns assignment copies correctly
+    - add tests
     
-- cleanup builtins - make them take their own scope with only other builtins
-- add valueTypeOf
-- check arg types on fun call/ret
-- add option to take implicit this argument to builtinFunction
-- add array push builtin
 - builtins (nyi for anything needing external call state)
+
 - add test with struct constructor and out-of-order field names, and mutation to capture order of execution
 - migrate builtin tests
 
@@ -206,8 +219,10 @@
 - make a pass to remove nyi and todos
 - add side-by-side execution test :)
 - refactor this.expect to use template strings like sol.assert as an optimization
+- test behavior of zero-ing out (delete, assign zero, pop) of complex storage datastructures. Are they recursively zeroed-out? For sized arrays? For structs? for unsized arrays?
 
 Eventually:
+    - move push implementaion in ArrayStorageView/BytesStorageView
     - cleanup nyi()s to 0
     - doc all functions
     - cleanup @todo-s

--- a/TODO.md
+++ b/TODO.md
@@ -163,12 +163,14 @@
 150 - test pop
 151 - check that normal internal calls handle arguments/returns assignment copies correctly
 152 - Add a test with fun returning an uninitialized local struct
+153 - units on literals
+154 - rationals in constant expressions
+
+- mock up external world stuff
 - builtins (nyi for anything needing external call state)
+- migrate builtin tests
 
 - add test with struct constructor and out-of-order field names, and mutation to capture order of execution
-- migrate builtin tests
-- units on literals
-
 - Idea: Tying it all toghether at the top-level:
     - interface PersistentState {
         artifact: ArtifactInfo;
@@ -226,6 +228,7 @@ Eventually:
     - doc all functions
     - cleanup @todo-s
     - cli
+    - file a bug to eventually elaborate the steps of constant expression eval by moving logic from solc-typed-ast's constant eval. Note this requires making Value = | Decimal to support rationals.
 
 Writing ideas:
     - the design choice of producing a high-level trace opens up the possibilities for establishing bisimulations!!

--- a/TODO.md
+++ b/TODO.md
@@ -140,13 +140,23 @@
 127 - test calling Library function from another file that depends on local globals and local constant contract vars that are shadowed in the cur scope
 128 - test virtual abstract modifier
 129 - test virtual abstract function
-- merge & rel
-
+130 - merge & rel
+131    - move version
+132    - move artifact
+133    - make infer a local var and kill this.infer()
+134    - restore constantMap back to state
+135    - remove state from where relevant
+136 - make Interpreter artifact specific (i.e. move version, artifact and infer to it)
+    
 - cleanup builtins - make them take their own scope with only other builtins
 - add valueTypeOf
 - check arg types on fun call/ret
 - add option to take implicit this argument to builtinFunction
 - add array push builtin
+- builtins (nyi for anything needing external call state)
+- add test with struct constructor and out-of-order field names, and mutation to capture order of execution
+- migrate builtin tests
+
 - Idea: Tying it all toghether at the top-level:
     - interface PersistentState {
         artifact: ArtifactInfo;
@@ -180,19 +190,17 @@
 
 - need an "immutable" var space somewhere in the state
 
-- add test with struct constructor and out-of-order field names, and mutation to capture order of execution
-
 - make an exhaustive test for coercions from old code
 
 // ---------------
 - getters
     - test virtual function resolves to public getter
+    - note - getters are only ever called externally :)
 - external calls
 - add evalNew for contracts
 - more coercions
 - cli for playing
 - try/catch etc...
-- add builtins
 - add a test with array of maps in a struct and push
 
 - make a pass to remove nyi and todos

--- a/TODO.md
+++ b/TODO.md
@@ -161,9 +161,8 @@
 148 - add concretize tests
 149 - add union tests
 150 - test pop
-
-- check that normal internal calls handle arguments/returns assignment copies correctly
-- Add a test with fun returning an uninitialized local struct
+151 - check that normal internal calls handle arguments/returns assignment copies correctly
+152 - Add a test with fun returning an uninitialized local struct
 - builtins (nyi for anything needing external call state)
 
 - add test with struct constructor and out-of-order field names, and mutation to capture order of execution

--- a/TODO.md
+++ b/TODO.md
@@ -163,12 +163,12 @@
 150 - test pop
 
 - check that normal internal calls handle arguments/returns assignment copies correctly
-    - add tests
-    
+- Add a test with fun returning an uninitialized local struct
 - builtins (nyi for anything needing external call state)
 
 - add test with struct constructor and out-of-order field names, and mutation to capture order of execution
 - migrate builtin tests
+- units on literals
 
 - Idea: Tying it all toghether at the top-level:
     - interface PersistentState {

--- a/src/interp/builtins.ts
+++ b/src/interp/builtins.ts
@@ -13,7 +13,7 @@ import {
     uint256
 } from "sol-dbg";
 import { bytes1, makeZeroValue } from "./utils";
-import { bytesToHex, concatBytes } from "@ethereumjs/util";
+import { concatBytes } from "@ethereumjs/util";
 
 function getArgs(numArgs: number, state: State): Value[] {
     const res: Value[] = [];
@@ -114,10 +114,12 @@ export const popBuiltin = new BuiltinFunction(
     "pop",
     new BuiltinFunctionType(
         "pop",
-        [new TUnion([
+        [
+            new TUnion([
                 new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Storage),
                 new sol.PointerType(new sol.BytesType(), sol.DataLocation.Storage)
-            ])],
+            ])
+        ],
         []
     ),
     (interp: Interpreter, state: State): Value[] => {
@@ -149,7 +151,6 @@ export const popBuiltin = new BuiltinFunction(
                 interp.runtimeError(EmptyArrayPop, `pop() from empty array`);
             }
 
-            console.error(`Popping from ${bytesToHex(bytes)} to ${bytesToHex(bytes.slice(0, -1))}`)
             state.storage = arr.encode(bytes.slice(0, -1), state.storage);
             // @todo zero-out deleted element
         }

--- a/src/interp/builtins.ts
+++ b/src/interp/builtins.ts
@@ -1,22 +1,160 @@
 import { BuiltinFunctionType, types } from "solc-typed-ast";
 import * as sol from "solc-typed-ast";
-import { BuiltinFunction, Value } from "./value";
+import { BuiltinFunction, none, Value } from "./value";
 import { State } from "./state";
-import { Assert } from "./exceptions";
+import { Assert, EmptyArrayPop, InternalError } from "./exceptions";
 import { Interpreter } from "./interp";
+import { TOptional, TUnion, TVar } from "./polymorphic";
+import {
+    ArrayStorageView,
+    BytesStorageView,
+    DecodingFailure,
+    IntStorageView,
+    uint256
+} from "sol-dbg";
+import { bytes1, makeZeroValue } from "./utils";
+import { bytesToHex, concatBytes } from "@ethereumjs/util";
+
+function getArgs(numArgs: number, state: State): Value[] {
+    const res: Value[] = [];
+    sol.assert(state.scope !== undefined, ``);
+    for (let i = 0; i < numArgs; i++) {
+        const argV = state.scope.lookup(`arg_${i}`);
+        sol.assert(argV !== undefined, ``);
+        res.push(argV);
+    }
+
+    return res;
+}
 
 export const assertBuiltin = new BuiltinFunction(
     "assert",
     new BuiltinFunctionType("assert", [types.bool], []),
-    (interp: Interpreter, state: State, args: Value[]): Value[] => {
-        if (args.length != 1 || typeof args[0] !== "boolean") {
-            sol.assert(false, `Unexpected args for assert: ${args}`);
-        }
+    (interp: Interpreter, state: State): Value[] => {
+        const [flag] = getArgs(1, state);
 
-        if (!args[0]) {
+        if (!flag) {
             throw new Assert(interp.curNode, interp.trace, ``);
         }
 
         return [];
     }
+);
+
+const a = new TVar("a");
+const b = new TVar("b");
+
+export const pushBuiltin = new BuiltinFunction(
+    "push",
+    new BuiltinFunctionType(
+        "push",
+        [
+            new TUnion([
+                new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Storage),
+                new sol.PointerType(new sol.BytesType(), sol.DataLocation.Storage)
+            ]),
+            // Note we allow the new element type to be different from the array element type to support things like
+            // arr.push("foo") since "foo" is a memory string. We handle the
+            // copy inside the push() builtin. We can't do it in the caller
+            // context since we don't know the exact location in storage yet.
+            new TOptional(b)
+        ],
+        []
+    ),
+    (interp: Interpreter, state: State, nArgs): Value[] => {
+        const args = getArgs(nArgs, state);
+        const arr = args[0] as ArrayStorageView | BytesStorageView;
+        let el: Value;
+
+        if (args.length > 1) {
+            el = args[1];
+        } else {
+            const elT = arr instanceof ArrayStorageView ? arr.type.elementT : bytes1;
+            el = makeZeroValue(elT, state);
+        }
+
+        if (arr instanceof ArrayStorageView) {
+            const sizeView = new IntStorageView(uint256, [arr.key, arr.endOffsetInWord]);
+            const curSize = sizeView.decode(state.storage);
+
+            if (curSize instanceof DecodingFailure) {
+                interp.fail(InternalError, `push(): couldn't decode array size`);
+            }
+
+            state.storage = sizeView.encode(curSize + 1n, state.storage);
+
+            const elView = arr.indexView(curSize, state.storage);
+
+            if (elView instanceof DecodingFailure) {
+                interp.fail(InternalError, `push(): couldn't get new element view`);
+            }
+
+            if (el !== none) {
+                interp.assign(elView, el, state);
+            }
+        } else {
+            let bytes = arr.decode(state.storage);
+
+            if (bytes instanceof DecodingFailure) {
+                interp.fail(InternalError, `push(): couldn't decode bytes`);
+            }
+
+            const newByte = el instanceof Uint8Array ? el : new Uint8Array([Number(el)]);
+
+            bytes = concatBytes(bytes, newByte);
+            state.storage = arr.encode(bytes, state.storage);
+        }
+
+        return [];
+    },
+    true
+);
+
+export const popBuiltin = new BuiltinFunction(
+    "pop",
+    new BuiltinFunctionType(
+        "pop",
+        [new TUnion([
+                new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Storage),
+                new sol.PointerType(new sol.BytesType(), sol.DataLocation.Storage)
+            ])],
+        []
+    ),
+    (interp: Interpreter, state: State): Value[] => {
+        const args = getArgs(1, state);
+        const arr = args[0] as ArrayStorageView | BytesStorageView;
+
+        if (arr instanceof ArrayStorageView) {
+            const sizeView = new IntStorageView(uint256, [arr.key, arr.endOffsetInWord]);
+            const curSize = sizeView.decode(state.storage);
+
+            if (curSize instanceof DecodingFailure) {
+                interp.fail(InternalError, `pop(): couldn't decode array size`);
+            }
+
+            if (curSize === 0n) {
+                interp.runtimeError(EmptyArrayPop, `pop() from empty array`);
+            }
+
+            state.storage = sizeView.encode(curSize - 1n, state.storage);
+            // @todo zero-out deleted element
+        } else {
+            const bytes = arr.decode(state.storage);
+
+            if (bytes instanceof DecodingFailure) {
+                interp.fail(InternalError, `pop(): couldn't decode bytes`);
+            }
+
+            if (bytes.length === 0) {
+                interp.runtimeError(EmptyArrayPop, `pop() from empty array`);
+            }
+
+            console.error(`Popping from ${bytesToHex(bytes)} to ${bytesToHex(bytes.slice(0, -1))}`)
+            state.storage = arr.encode(bytes.slice(0, -1), state.storage);
+            // @todo zero-out deleted element
+        }
+
+        return [];
+    },
+    true
 );

--- a/src/interp/index.ts
+++ b/src/interp/index.ts
@@ -1,3 +1,4 @@
 export * from "./step";
 export { Interpreter } from "./interp";
 export * from "./builtins";
+export * from "./polymorphic";

--- a/src/interp/interp.ts
+++ b/src/interp/interp.ts
@@ -35,7 +35,8 @@ import {
     ArtifactInfo,
     DefaultAllocator,
     ImmMap,
-    ZERO_ADDRESS
+    ZERO_ADDRESS,
+    isPoison
 } from "sol-dbg";
 import * as sol from "solc-typed-ast";
 import { WorldInterface, State, SolMessage } from "./state";
@@ -868,6 +869,7 @@ export class Interpreter {
         } else if (lvalue instanceof BaseLocalView) {
             this.expect(
                 !(lvalue.type instanceof sol.PointerType) ||
+                    isPoison(rvalue) ||
                     (rvalue instanceof View && lvalue.type.to.pp() === rvalue.type.pp())
             );
             lvalue.encode(rvalue);

--- a/src/interp/polymorphic.ts
+++ b/src/interp/polymorphic.ts
@@ -1,0 +1,332 @@
+import { ExpStructType } from "sol-dbg";
+import * as sol from "solc-typed-ast";
+
+export abstract class BasePolyType extends sol.TypeNode {}
+
+export class BaseTVar extends BasePolyType {
+    constructor(public readonly name: string) {
+        super();
+    }
+
+    pp(): string {
+        return `<TVar ${this.name}>`;
+    }
+}
+
+// Single type var
+export class TVar extends BaseTVar {}
+
+export class TUnion extends BaseTVar {
+    private static ctr: number = 0;
+    constructor(public readonly options: sol.TypeNode[]) {
+        super(`__tunion__${TUnion.ctr++}`);
+    }
+
+    pp(): string {
+        return `<${this.options.map((opT) => opT.pp()).join("| ")}>`;
+    }
+}
+
+// TOptional is a hack to support checking optional arguments.
+// Note that it is only handled by concretize, it is not supported by unify.
+export class TOptional extends BasePolyType {
+    constructor(public readonly subT: sol.TypeNode) {
+        super();
+    }
+
+    pp(): string {
+        return `<optional ${this.subT.pp()}>`;
+    }
+}
+
+// Type var corresponding to the remaining arguments of a function(something like ...args: any[])
+// Note that it is only handled by concretize, it is not supported by unify.
+export class TRest extends BaseTVar {
+    private static ctr: number = 0;
+
+    constructor() {
+        super(`__trest__${TRest.ctr++}`);
+    }
+}
+
+function containsTVar(t: sol.TypeNode, v: BaseTVar): boolean {
+    if (t instanceof BaseTVar && t.name === v.name) {
+        return true;
+    }
+
+    if (t instanceof sol.PointerType) {
+        return containsTVar(t.to, v);
+    }
+
+    if (t instanceof sol.ArrayType) {
+        return containsTVar(t.elementT, v);
+    }
+
+    if (t instanceof ExpStructType) {
+        for (const [, fieldT] of t.fields) {
+            if (containsTVar(fieldT, v)) {
+                return true;
+            }
+        }
+    }
+
+    if (t instanceof TOptional) {
+        return containsTVar(t.subT, v);
+    }
+
+    if (t instanceof TUnion) {
+        for (const opt of t.options) {
+            if (containsTVar(opt, v)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    return false;
+}
+
+export function isPolymorphic(t: sol.TypeNode): boolean {
+    if (t instanceof BasePolyType) {
+        return true;
+    }
+
+    if (t instanceof sol.PointerType) {
+        return isPolymorphic(t.to);
+    }
+
+    if (t instanceof sol.ArrayType) {
+        return isPolymorphic(t.elementT);
+    }
+
+    if (t instanceof ExpStructType) {
+        for (const [, fieldT] of t.fields) {
+            if (isPolymorphic(fieldT)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+export type TSubst = Map<string, sol.TypeNode>;
+
+/**
+ * Returns true IFF t1 unifies with t2 under type substitution subst. It modifies subst
+ */
+export function unify(t1: sol.TypeNode, t2: sol.TypeNode, subst: TSubst): boolean {
+    t1 = substitute(t1, subst);
+    t2 = substitute(t2, subst);
+
+    if (t1.pp() === t2.pp()) {
+        return true;
+    }
+
+    if (t2 instanceof TVar) {
+        const tmp = t2;
+        t2 = t1;
+        t1 = tmp;
+    }
+
+    if (t1 instanceof TVar) {
+        // Circular dependency
+        if (containsTVar(t2, t1)) {
+            return false;
+        }
+
+        subst.set(t1.name, t2);
+        return true;
+    }
+
+    if (t1 instanceof sol.ArrayType && t2 instanceof sol.ArrayType && t1.size === t2.size) {
+        return unify(t1.elementT, t2.elementT, subst);
+    }
+
+    if (
+        t1 instanceof ExpStructType &&
+        t2 instanceof ExpStructType &&
+        t1.fields.length === t2.fields.length
+    ) {
+        for (let i = 0; i < t1.fields.length; i++) {
+            const [f1Name, f1Type] = t1.fields[i];
+            const [f2Name, f2Type] = t2.fields[i];
+
+            if (f1Name !== f2Name || !unify(f1Type, f2Type, subst)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (t1 instanceof sol.PointerType && t2 instanceof sol.PointerType) {
+        // As a hack we consider DataLocation.Default to be a * for locations
+        if (
+            t1.location !== t2.location &&
+            t1.location !== sol.DataLocation.Default &&
+            t2.location !== sol.DataLocation.Default
+        ) {
+            return false;
+        }
+
+        return unify(t1.to, t2.to, subst);
+    }
+
+    // Unify tuples with some fields being optional
+    if (t1 instanceof sol.TupleType && t2 instanceof sol.TupleType) {
+        if (t2.elements.length < t1.elements.length) {
+            const tmp: sol.TupleType = t1;
+            t1 = t2 as sol.TupleType;
+            t2 = tmp as sol.TupleType;
+        }
+
+        // Pacify typescript
+        sol.assert(t1 instanceof sol.TupleType && t2 instanceof sol.TupleType, ``);
+
+        for (let i = 0; i < t1.elements.length; i++) {
+            const t1El = t1.elements[i];
+            const t2El = t2.elements[i];
+
+            sol.assert(t1El !== null && t2El !== null, ``);
+
+            if (!unify(t1El, t2El, subst)) {
+                return false;
+            }
+        }
+
+        for (let i = t1.elements.length; i < t2.elements.length; i++) {
+            if (!(t2.elements[i] instanceof TOptional)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (t2 instanceof TUnion) {
+        const tmp = t1;
+        t1 = t2;
+        t2 = tmp;
+    }
+
+    if (t1 instanceof TUnion) {
+        for (const optT of t1.options) {
+            const substCopy: TSubst = new Map(subst.entries());
+
+            if (unify(optT, t2, substCopy)) {
+                for (const [k, v] of substCopy) {
+                    subst.set(k, v);
+                }
+
+                subst.set(t1.name, optT);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    return false;
+}
+
+/**
+ * Given a polymorphic type `t1` and a concrete type `t2` that should (mostly)
+ * agree with it, concretize `t1` to (mostly) match `t2`.  The context is that
+ * this is used to concretize the polymorphic types of builtins according to the
+ * call site. The concrete types may not be exactly unifiable due to implicit
+ * casts. For example in `arr.push("abc")`  the concrete args [string storage[]
+ * storage, string memory] don't unify with the polymorphic args [T[] storage,
+ * T]).
+ *
+ * However its sufficient to concretize tuple args left to right until they are fully concrete
+ * to get the right concrete type.
+ *
+ * Also this handles TRest.
+ */
+export function concretize(
+    formalTypes: sol.TypeNode[],
+    concreteTypes: sol.TypeNode[]
+): [sol.TypeNode[], TSubst] {
+    const subst: TSubst = new Map();
+    const res: sol.TypeNode[] = [];
+
+    for (let i = 0; i < formalTypes.length; i++) {
+        let formalT = formalTypes[i];
+
+        if (formalT instanceof TRest) {
+            res.push(...(concreteTypes.slice(i) as sol.TypeNode[]));
+            sol.assert(
+                i === formalTypes.length - 1,
+                `Unexpected TRest not in the last position in concretize`
+            );
+            return [res, subst];
+        }
+
+        if (formalT instanceof TOptional) {
+            if (i >= concreteTypes.length) {
+                continue;
+            }
+
+            formalT = formalT.subT;
+        }
+
+        let substitutedT = substitute(formalT, subst);
+        sol.assert(i < concreteTypes.length, `Fewer concrete types than formal`);
+        const concreteT = concreteTypes[i] as sol.TypeNode;
+
+        if (isPolymorphic(substitutedT)) {
+            sol.assert(
+                unify(substitutedT, concreteT, subst),
+                `Couldn't unify {0} and {1}`,
+                substitutedT,
+                concreteT
+            );
+            substitutedT = substitute(substitutedT, subst);
+        }
+
+        res.push(substitutedT);
+    }
+
+    return [res, subst];
+}
+
+/**
+ * Replace all TVars inside `t` according to `subst`.
+ * As a small optimization, if no substitution happened, we return the same type without allocations
+ */
+export function substitute(t: sol.TypeNode, subst: TSubst): sol.TypeNode {
+    if (t instanceof BaseTVar) {
+        const res = subst.get(t.name);
+        return res !== undefined ? substitute(res, subst) : t;
+    }
+
+    if (t instanceof sol.PointerType) {
+        const toT = substitute(t.to, subst);
+        return toT === t.to ? t : new sol.PointerType(toT, t.location, t.kind);
+    }
+
+    if (t instanceof sol.ArrayType) {
+        const elT = substitute(t.elementT, subst);
+        return elT === t.elementT ? t : new sol.ArrayType(elT, t.size);
+    }
+
+    if (t instanceof ExpStructType) {
+        const fields: Array<[string, sol.TypeNode]> = t.fields.map(([name, fieldT]) => [
+            name,
+            substitute(fieldT, subst)
+        ]);
+        return new ExpStructType(t.name, fields);
+    }
+
+    if (t instanceof TOptional) {
+        const innerT = substitute(t.subT, subst);
+
+        return innerT === t.subT ? t : new TOptional(innerT);
+    }
+
+    // Shouldn't contain types inside
+    return t;
+}

--- a/src/interp/scope.ts
+++ b/src/interp/scope.ts
@@ -15,8 +15,7 @@ import {
 import { BaseStorageView, makeStorageView, StructStorageView } from "sol-dbg";
 import { lt } from "semver";
 import { ArrayLikeLocalView, PrimitiveLocalView, PointerLocalView } from "./view";
-import { isValueType, makeZeroValue, panic } from "./utils";
-import { assertBuiltin } from "./builtins";
+import { isValueType, panic } from "./utils";
 
 /**
  * Identifier scopes.  Note that scopes themselves dont store values - only the
@@ -184,9 +183,10 @@ export class LocalsScope extends BaseScope {
     constructor(
         public readonly node: LocalsScopeNodeType,
         state: State,
+        version: string,
         _next: BaseScope | undefined
     ) {
-        const defTypesMap = LocalsScope.detectIds(node, state.version);
+        const defTypesMap = LocalsScope.detectIds(node, version);
 
         let name: string;
         if (node instanceof sol.Block || node instanceof sol.UncheckedBlock) {
@@ -449,12 +449,12 @@ export class GlobalScope extends BaseScope {
     constructor(
         public readonly unit: sol.SourceUnit,
         state: State,
+        infer: sol.InferType,
         _next: BaseScope | undefined
     ) {
         const defMap = new Map<string, sol.TypeNode>();
-        const infer = new sol.InferType(state.version);
-
         const declMap = GlobalScope.gatherDefs(unit);
+
         for (const [name, decl] of declMap) {
             const type =
                 decl instanceof sol.VariableDeclaration
@@ -535,95 +535,4 @@ export class BuiltinsScope extends BaseScope {
     _set(): void {
         sol.assert(false, `Can't set a builtin after initialization`);
     }
-}
-
-export function makeBuiltinScope(state: State): BuiltinsScope {
-    const builtins = [assertBuiltin];
-    return new BuiltinsScope(
-        builtins.map((b) => [b.name, b.type, b]),
-        state,
-        undefined
-    );
-}
-
-/**
- * Given a node make a scope for it up to the containing contract.
- * This will include the builtins, globals and contract scopes.
- *
- * This scope is used to:
- * 1. Compute constant expressions
- * 2. As a basis for dynamic runtime scopes. Those build on this scope with LocalScopes for function args, locals, etc..
- */
-export function makeStaticScope(nd: sol.ASTNode | undefined, state: State): BaseScope {
-    const scopeNodes: Array<sol.SourceUnit | sol.ContractDefinition> = [];
-
-    while (nd !== undefined) {
-        if (nd instanceof sol.SourceUnit || nd instanceof sol.ContractDefinition) {
-            scopeNodes.push(nd);
-        }
-
-        nd = nd.parent;
-    }
-
-    scopeNodes.reverse();
-    let scope: BaseScope = makeBuiltinScope(state);
-
-    for (const nd of scopeNodes) {
-        if (nd instanceof sol.SourceUnit) {
-            scope = new GlobalScope(nd, state, scope);
-        } else {
-            const infer = new sol.InferType(state.version);
-            scope = new ContractScope(nd, infer, state, scope);
-        }
-    }
-
-    return scope;
-}
-
-/**
- * Make the lexical scope for a given function or modifier. This also sets the argument values (and zero values for returns) for that scope.
- * @param nd
- * @param args
- * @param state
- * @param infer
- * @returns
- */
-export function makeScope(
-    nd: sol.FunctionDefinition | sol.ModifierDefinition,
-    args: Value[],
-    state: State,
-    infer: sol.InferType
-): BaseScope {
-    const staticScope = makeStaticScope(nd, state);
-    const localNames = nd.vParameters.vParameters.map((d) => d.name);
-
-    // We keep the returns in the function scope as well
-    if (nd instanceof sol.FunctionDefinition) {
-        localNames.push(
-            ...nd.vReturnParameters.vParameters.map((ret, i) => LocalsScope.returnName(ret, i))
-        );
-        args.push(
-            ...nd.vReturnParameters.vParameters.map((ret) => {
-                const type = simplifyType(
-                    infer.variableDeclarationToTypeNode(ret),
-                    infer,
-                    undefined
-                );
-                return makeZeroValue(type, state);
-            })
-        );
-    }
-
-    sol.assert(
-        localNames.length === args.length,
-        `Mismatch in args in call to ${nd.name} expected ${localNames.length} got ${args.length}`
-    );
-
-    const res = new LocalsScope(nd, state, staticScope);
-
-    for (let i = 0; i < localNames.length; i++) {
-        res.set(localNames[i], args[i]);
-    }
-
-    return res;
 }

--- a/src/interp/state.ts
+++ b/src/interp/state.ts
@@ -47,7 +47,6 @@ export interface InternalCallFrame {
 
 export interface State {
     //Solidity version of the current contract
-    version: string;
     storage: Storage;
     memory: Memory;
     memAllocator: Allocator;
@@ -58,10 +57,9 @@ export interface State {
     constantsMap: Map<number, BaseMemoryView<BaseValue, TypeNode>>;
 }
 
-export function makeEmptyState(version: string): State {
+export function makeEmptyState(): State {
     const memAllocator = new DefaultAllocator();
     return {
-        version,
         storage: ImmMap.fromEntries([]),
         memory: memAllocator.memory,
         memAllocator,

--- a/src/interp/state.ts
+++ b/src/interp/state.ts
@@ -17,6 +17,7 @@ import {
     VariableDeclaration
 } from "solc-typed-ast";
 import { Allocator } from "sol-dbg";
+import { BuiltinFunction } from "./value";
 
 export interface CallResult {
     reverted: boolean;
@@ -40,7 +41,7 @@ export interface SolMessage {
 }
 
 export interface InternalCallFrame {
-    callee: FunctionDefinition | VariableDeclaration;
+    callee: FunctionDefinition | VariableDeclaration | BuiltinFunction;
     scope: LocalsScope;
     curModifier: ModifierInvocation | undefined;
 }

--- a/src/interp/tc.ts
+++ b/src/interp/tc.ts
@@ -1,0 +1,75 @@
+import * as sol from "solc-typed-ast";
+import { Value } from "./value";
+import { ExpStructType, fits, nyi, View } from "sol-dbg";
+import { ppValue } from "./pp";
+import { Address } from "@ethereumjs/util";
+import { isArrayLikeView } from "./view";
+import { isStructView } from "./utils";
+import { TOptional } from "./polymorphic";
+
+export function valueIsOfType(v: Value, t: sol.TypeNode): boolean {
+    if (t instanceof sol.IntLiteralType) {
+        return typeof v === "bigint";
+    }
+
+    if (t instanceof sol.IntType) {
+        return typeof v === "bigint" && fits(v, t);
+    }
+
+    if (t instanceof sol.FixedBytesType) {
+        return v instanceof Uint8Array && v.length === t.size;
+    }
+
+    if (t instanceof sol.AddressType) {
+        return v instanceof Address;
+    }
+
+    if (t instanceof sol.BoolType) {
+        return typeof v === "boolean";
+    }
+
+    if (t instanceof sol.ArrayType) {
+        // @todo check size on statically sized arrays
+        return isArrayLikeView(v);
+    }
+
+    if (t instanceof ExpStructType) {
+        return isStructView(v);
+    }
+
+    if (t instanceof sol.PointerType) {
+        return v instanceof View && valueIsOfType(v, t.to);
+    }
+
+    if (t instanceof TOptional) {
+        return valueIsOfType(v, t.subT);
+    }
+
+    if (t instanceof sol.TupleType) {
+        if (!(v instanceof Array)) {
+            return false;
+        }
+
+        if (v.length > t.elements.length) {
+            return false;
+        }
+
+        for (let i = 0; i < v.length; i++) {
+            const elT = t.elements[i];
+            sol.assert(elT !== null, ``);
+            if (!valueIsOfType(v[i], elT)) {
+                return false;
+            }
+        }
+
+        for (let i = v.length; i < t.elements.length; i++) {
+            if (!(t.elements[i] instanceof TOptional)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    nyi(`valueIsOfType(${ppValue(v)}, ${t.pp()})`);
+}

--- a/src/interp/utils.ts
+++ b/src/interp/utils.ts
@@ -49,8 +49,7 @@ export function makeZeroValue(t: sol.TypeNode, state: State): PrimitiveValue {
     }
 
     if (t instanceof sol.PointerType) {
-        // @todo Something feels off here. It would be cleaner if all pointer types are 0-initialized to poison.
-        // Do we really allocate memory for uninitialized locals? Add a test with fun returning an uninitialized local struct;
+        // The only reazon we treat mem pointers differently is that uninitialized local mem variables are pre-allocated by default.
         if (t.location === sol.DataLocation.Memory) {
             let zeroValue: BaseValue;
 

--- a/src/interp/utils.ts
+++ b/src/interp/utils.ts
@@ -19,7 +19,7 @@ import {
     Storage
 } from "sol-dbg";
 import * as sol from "solc-typed-ast";
-import { none } from "./value";
+import { none, Value } from "./value";
 import { CallResult, State, WorldInterface } from "./state";
 import { BaseLocalView } from "./view";
 
@@ -294,3 +294,15 @@ export function isMethod(f: sol.FunctionDefinition | sol.VariableDeclaration): b
 }
 
 export const bytes1 = new sol.FixedBytesType(1);
+
+export function solcValueToValue(solV: sol.Value): Value {
+    if (typeof solV === "bigint" || typeof solV === "boolean") {
+        return solV;
+    }
+
+    if (solV instanceof Buffer) {
+        return new Uint8Array(solV);
+    }
+
+    sol.assert(false, `Cannot convert solc value ${solV}`);
+}

--- a/src/interp/utils.ts
+++ b/src/interp/utils.ts
@@ -291,3 +291,5 @@ export function isMethod(f: sol.FunctionDefinition | sol.VariableDeclaration): b
         f.vScope.kind === sol.ContractKind.Contract
     );
 }
+
+export const bytes1 = new sol.FixedBytesType(1);

--- a/src/interp/utils.ts
+++ b/src/interp/utils.ts
@@ -49,6 +49,8 @@ export function makeZeroValue(t: sol.TypeNode, state: State): PrimitiveValue {
     }
 
     if (t instanceof sol.PointerType) {
+        // @todo Something feels off here. It would be cleaner if all pointer types are 0-initialized to poison.
+        // Do we really allocate memory for uninitialized locals? Add a test with fun returning an uninitialized local struct;
         if (t.location === sol.DataLocation.Memory) {
             let zeroValue: BaseValue;
 

--- a/test/samples/RationalTest.sol
+++ b/test/samples/RationalTest.sol
@@ -1,0 +1,68 @@
+pragma solidity 0.4.24;
+
+// https://solidity.readthedocs.io/en/develop/types.html#fixed-point-numbers
+contract RationalTest {
+    // https://solidity.readthedocs.io/en/v0.4.21/units-and-global-variables.html#ether-units
+    // https://solidity.readthedocs.io/en/v0.5.3/units-and-global-variables.html#ether-units
+    function subdenominationEtherTest() public {
+        assert(1 wei == 1);
+        assert(1 szabo == 1e12);
+        assert(1 finney == 1e15);
+        assert(1 ether == 1e18);
+
+        assert(1 szabo == 1000000000000 wei);
+        assert(1 finney == 1000 szabo);
+        assert(1 ether == 1000 finney);
+
+        assert(0.5 ether == 500 finney);
+        assert(0.5 finney == 500 szabo);
+        assert(0.5 szabo == 500000000000 wei);
+
+        assert(1.5 ether < 2.5 ether);
+        assert(-1.5 finney > -2 finney);
+        assert(0.001 ether == 1 finney);
+    }
+
+    // https://solidity.readthedocs.io/en/v0.4.21/units-and-global-variables.html#time-units
+    function subdenominationTimeTest() public {
+        assert(1 == 1 seconds);
+        assert(1 minutes == 60 seconds);
+        assert(1 hours == 60 minutes);
+        assert(1 days == 24 hours);
+        assert(1 weeks == 7 days);
+        assert(1 years == 365 days); // obsolete as of 0.5+, so comment it out for Solc 0.5+
+
+        assert(0.5 hours == 30 minutes);
+        assert(0.1 minutes == 6 seconds);
+        assert(2 * 6 seconds == 0.2 minutes);
+    }
+
+    function mathTest() public {
+        assert((-0.7 * (0.8)) * 100 finney == -0.056 ether);
+        assert((0.7 ** 2) * 2 ether == 0.98 ether);
+        assert((0.15 + 10.05) * 10 == 102);
+        assert(+(0.03 + (-0.005)) * 1000 == 25);
+        assert(1.3 / 0.5 * 10 == 26);
+        assert(1.3 / 0.5 * 10 == 26);
+        assert(3.3 % 3 * 10 == 3);
+        assert(0.142857 * -1000 * -1000 == 142857);
+        assert(-413.0 % 59.0 == -0);
+        assert((0.1 + 0.2) * 10 == 0.3 * 10);
+        assert(0xA * 0.5 == 5);
+        assert(0xFE * 0.5 == 127);
+    }
+
+    function extremeDenominatedValues() public {
+        assert(100000000000000000000000000000000000000000000000000000000000 ether == 100000000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(100000000000000000000000000000000000000000000000000000000000000 finney == 100000000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(100000000000000000000000000000000000000000000000000000000000000000 szabo == 100000000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(100000000000000000000000000000000000000000000000000000000000000000000000000000 wei == 100000000000000000000000000000000000000000000000000000000000000000000000000000);
+
+        assert(100000000000000000000000000000000000000000000000000000000000000000000000000000 seconds == 100000000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(1000000000000000000000000000000000000000000000000000000000000000000000000000 minutes == 60000000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(10000000000000000000000000000000000000000000000000000000000000000000000000 hours == 36000000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(1000000000000000000000000000000000000000000000000000000000000000000000000 days == 86400000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(100000000000000000000000000000000000000000000000000000000000000000000000 weeks == 60480000000000000000000000000000000000000000000000000000000000000000000000000);
+        assert(1000000000000000000000000000000000000000000000000000000000000000000000 years == 31536000000000000000000000000000000000000000000000000000000000000000000000000);
+    }
+}

--- a/test/samples/assignments.sol
+++ b/test/samples/assignments.sol
@@ -176,7 +176,7 @@ contract Assignments {
         assert (a == 42);
     }
 
-    function tupleEvaluateAllInitialExpressions() public returns(uint){
+    function tupleEvaluateAllInitialExpressions() public returns(uint) {
         uint foo = 42;
         (uint8 a, , string memory c, ) = (1, foo=1337, "abc",4);
         assert(a == 1 && foo == 1337);

--- a/test/samples/call_implicit_casts.sol
+++ b/test/samples/call_implicit_casts.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.8.28;
+
+contract Foo {
+    function foo(uint256 a, bytes2 b, bytes memory c) internal {
+        assert(c.length == 2);
+        assert(a == 1);
+        assert(b == 0x0102);
+    }
+
+    function retStorBytes() internal returns (bytes storage) {
+        return sB;
+    }
+
+    function checkMemBytes(bytes memory m) internal {
+        assert(m.length == 2 && m[1] == 0x02);
+    }
+        
+    bytes sB;
+
+    function main() public {
+        sB = hex"0102";
+        foo(1, 0x0102, sB);
+
+        bytes memory mB = retStorBytes();
+        assert(mB.length == 2 && mB[1] == 0x02);
+
+        checkMemBytes(retStorBytes());
+    }
+}

--- a/test/samples/push.sol
+++ b/test/samples/push.sol
@@ -1,0 +1,47 @@
+pragma solidity 0.8.28;
+
+contract Foo {
+    uint8[] u8Arr;
+    bytes[] sArr;
+    bytes bts;
+
+    uint[][] u2dArr;
+
+    function main() public {
+        assert(u8Arr.length == 0);
+        u8Arr.push(1);
+        assert(u8Arr.length == 1 && u8Arr[0] == 1);
+        u8Arr.push();
+        assert(u8Arr.length == 2 && u8Arr[0] == 1 && u8Arr[1] == 0);
+
+        sArr.push(hex"2a2b2c");
+        sArr.push();
+
+        assert(sArr.length == 2 && sArr[0].length == 3 && sArr[1].length == 0);
+
+        bts = hex"010203";
+        assert(bts.length == 3);
+        
+        bts.push();
+        assert(bts.length == 4 && bts[2] == 0x03 && bts[3] == 0x00);
+
+        // pop
+        u8Arr.pop();
+        assert(u8Arr.length == 1 && u8Arr[0] == 1);
+        u8Arr.push(3);
+        assert(u8Arr.length == 2 && u8Arr[0] == 1 && u8Arr[1] == 3);
+        u8Arr.pop();
+        u8Arr.push();
+        assert(u8Arr.length == 2 && u8Arr[0] == 1 && u8Arr[1] == 0);
+
+        sArr.pop();
+        assert(sArr.length == 1 && sArr[0].length == 3);
+        sArr.push(hex"0a");
+        assert(sArr.length == 2 && sArr[0].length == 3 && sArr[1].length == 1);
+
+        bts.pop();
+        assert(bts.length == 3 && bts[2] == 0x03);
+        bts.push(0x1f);
+        assert(bts.length == 4 && bts[2] == 0x03 && bts[3] == 0x1f);
+    }
+}

--- a/test/samples/return_uninitialized_mem_struct.sol
+++ b/test/samples/return_uninitialized_mem_struct.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.8.28;
+
+contract Foo  {
+    struct F {
+        uint a;
+        uint b;
+    }
+
+    function getF() internal returns (F memory) {
+    }
+
+    function main() public {
+        F memory f1 = getF();
+        F memory f2 = getF();
+
+        f1.a = 1;
+        f2.a = 2;
+        assert(f1.a == 1 && f2.a == 2);
+    }
+}

--- a/test/samples/units.sol
+++ b/test/samples/units.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.8.28;
+
+contract Foo {
+    function main() public {
+        assert(1 wei == 1);
+        assert(1 gwei == 1e9);
+        assert(1 ether == 1e18);
+
+        assert(1 == 1 seconds);
+        assert(1 minutes == 60 seconds);
+        assert(1 hours == 60 minutes);
+        assert(1 days == 24 hours);
+        assert(1 weeks == 7 days);
+    }
+}

--- a/test/unit/call.spec.ts
+++ b/test/unit/call.spec.ts
@@ -89,7 +89,8 @@ const samples: Array<
     ["modifiers.sol", "Foo", "main", [], [], []],
     ["global_fun_main.sol", "Foo", "main", [], [], []],
     ["virtual_modifiers.sol", "Child", "main", [], [], []],
-    ["virtual_abstract_method.sol", "Child", "main", [], [], []]
+    ["virtual_abstract_method.sol", "Child", "main", [], [], []],
+    ["push.sol", "Foo", "main", [], [], []]
 ];
 
 describe("Simple function call tests", () => {
@@ -130,9 +131,17 @@ describe("Simple function call tests", () => {
                 fun.vParameters.vParameters.map((d) => d.name),
                 argVals
             );
+            const argTs = fun.vParameters.vParameters.map((decl) =>
+                interp._infer.variableDeclarationToTypeNode(decl)
+            );
             if (expectedReturns instanceof Array) {
                 try {
-                    const returns = interp.callInternal(fun, encodeMemArgs(args, state), state);
+                    const returns = interp.callInternal(
+                        fun,
+                        encodeMemArgs(args, state),
+                        argTs,
+                        state
+                    );
                     const decodedReturns = returns.map((ret) =>
                         ret instanceof View ? interp.decode(ret, state) : ret
                     );
@@ -152,7 +161,7 @@ describe("Simple function call tests", () => {
                 }
             } else {
                 expect(() => {
-                    interp.callInternal(fun, encodeMemArgs(args, state), state);
+                    interp.callInternal(fun, encodeMemArgs(args, state), argTs, state);
                 }).toThrow(expectedReturns);
             }
         });

--- a/test/unit/call.spec.ts
+++ b/test/unit/call.spec.ts
@@ -90,7 +90,8 @@ const samples: Array<
     ["global_fun_main.sol", "Foo", "main", [], [], []],
     ["virtual_modifiers.sol", "Child", "main", [], [], []],
     ["virtual_abstract_method.sol", "Child", "main", [], [], []],
-    ["push.sol", "Foo", "main", [], [], []]
+    ["push.sol", "Foo", "main", [], [], []],
+    ["call_implicit_casts.sol", "Foo", "main", [], [], []]
 ];
 
 describe("Simple function call tests", () => {

--- a/test/unit/call.spec.ts
+++ b/test/unit/call.spec.ts
@@ -91,7 +91,13 @@ const samples: Array<
     ["virtual_modifiers.sol", "Child", "main", [], [], []],
     ["virtual_abstract_method.sol", "Child", "main", [], [], []],
     ["push.sol", "Foo", "main", [], [], []],
-    ["call_implicit_casts.sol", "Foo", "main", [], [], []]
+    ["call_implicit_casts.sol", "Foo", "main", [], [], []],
+    ["units.sol", "Foo", "main", [], [], []],
+    ["return_uninitialized_mem_struct.sol", "Foo", "main", [], [], []],
+    ["RationalTest.sol", "RationalTest", "subdenominationEtherTest", [], [], []],
+    ["RationalTest.sol", "RationalTest", "subdenominationTimeTest", [], [], []],
+    ["RationalTest.sol", "RationalTest", "mathTest", [], [], []],
+    ["RationalTest.sol", "RationalTest", "extremeDenominatedValues", [], [], []]
 ];
 
 describe("Simple function call tests", () => {

--- a/test/unit/eval.spec.ts
+++ b/test/unit/eval.spec.ts
@@ -114,22 +114,25 @@ const samples: Array<[string, string, Array<[string, Value]>, Value]> = [
 
 describe("Eval unit tests", () => {
     let artifactManager: ArtifactManager;
-    let interp: Interpreter;
     let sampleMap: SampleMap;
 
     const fileNames = [...new Set<string>(samples.map(([name]) => name))];
 
     beforeAll(async () => {
         [artifactManager, sampleMap] = await loadSamples(fileNames);
-        interp = new Interpreter(worldFailMock, artifactManager);
     }, 10000);
 
     for (const [fileName, path, defs, expValue] of samples) {
         it(path, () => {
             const sample = sampleMap.get(fileName) as SampleInfo;
             const contract = sample.units[0].vContracts[0];
+            const interp = new Interpreter(
+                worldFailMock,
+                artifactManager,
+                artifactManager.getArtifact(contract)
+            );
             const expr = new sol.XPath(contract).query(path)[0] as sol.Expression;
-            const state = makeState(expr, artifactManager, ...defs);
+            const state = makeState(expr, interp, ...defs);
             expect(expr).toBeDefined();
             let v: any = interp.eval(expr, state);
 

--- a/test/unit/poly.spec.ts
+++ b/test/unit/poly.spec.ts
@@ -1,0 +1,249 @@
+import { ExpStructType, uint256, uint8 } from "sol-dbg";
+import * as sol from "solc-typed-ast";
+import { concretize, substitute, TOptional, TRest, TUnion, TVar, unify } from "../../src";
+
+const s1 = new ExpStructType("s1", [
+    ["a", sol.types.uint256],
+    ["b", sol.types.uint256]
+]);
+
+const s1_copy = new ExpStructType("s1", [
+    ["a", sol.types.uint256],
+    ["b", sol.types.uint256]
+]);
+
+const s2 = new ExpStructType("s2", [
+    ["a", sol.types.uint256],
+    ["c", sol.types.uint256]
+]);
+
+const s3 = new ExpStructType("s3", [
+    ["a", sol.types.uint256],
+    ["b", sol.types.uint160]
+]);
+
+const a = new TVar("a");
+const b = new TVar("b");
+const c = new TVar("c");
+
+const unificationSamples: Array<[sol.TypeNode, sol.TypeNode, boolean]> = [
+    [sol.types.uint160, sol.types.uint160, true],
+    [sol.types.uint256, sol.types.uint160, false],
+    [sol.types.bytesMemory, sol.types.bytesMemory, true],
+    [sol.types.bytesMemory, sol.types.stringMemory, false],
+    [sol.types.bytesMemory, sol.types.bytesCalldata, false],
+    [new sol.ArrayType(sol.types.uint160), new sol.ArrayType(sol.types.uint160), true],
+    [new sol.ArrayType(sol.types.uint160, 5n), new sol.ArrayType(sol.types.uint160), false],
+    [new sol.ArrayType(sol.types.uint160), new sol.ArrayType(sol.types.uint256), false],
+    [s1, s1_copy, true],
+    [s1, s2, false],
+    [s1, s3, false],
+    [a, b, true],
+    [
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ]),
+        new ExpStructType("a", [
+            ["f1", b],
+            ["f2", b]
+        ]),
+        true
+    ],
+    [
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ]),
+        new ExpStructType("a", [
+            ["f1", b],
+            ["f2", c]
+        ]),
+        true
+    ],
+    [
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ]),
+        new ExpStructType("a", [
+            ["f1", uint256],
+            ["f2", uint8]
+        ]),
+        false
+    ],
+    [
+        new sol.ArrayType(a),
+        new sol.ArrayType(new sol.PointerType(new sol.ArrayType(b), sol.DataLocation.Memory)),
+        true
+    ],
+    [
+        new sol.ArrayType(a),
+        new sol.ArrayType(new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory)),
+        false
+    ],
+    [
+        new ExpStructType("a", [
+            ["a", a],
+            ["b", new sol.ArrayType(uint256, 5n)]
+        ]),
+        new ExpStructType("a", [
+            ["a", new sol.PointerType(new sol.ArrayType(b), sol.DataLocation.Memory)],
+            ["b", b]
+        ]),
+        true
+    ],
+    [new sol.TupleType([a, b]), new sol.TupleType([b, c]), true],
+    [new sol.TupleType([a, a]), new sol.TupleType([uint256, uint8]), false],
+    [new TUnion([uint256, uint8]), uint8, true],
+    [new TUnion([uint256, uint8]), sol.types.address, false],
+    [new sol.TupleType([a]), new sol.TupleType([uint256, uint8]), false],
+    [new sol.ArrayType(a), new sol.ArrayType(uint8, 5n), false],
+    [new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory), new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Storage), false]
+];
+
+const substSamples: Array<[sol.TypeNode, sol.TypeNode, sol.TypeNode]> = [
+    [a, b, a],
+    [
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ]),
+        new ExpStructType("a", [
+            ["f1", b],
+            ["f2", b]
+        ]),
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ])
+    ],
+    [
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ]),
+        new ExpStructType("a", [
+            ["f1", b],
+            ["f2", c]
+        ]),
+        new ExpStructType("a", [
+            ["f1", a],
+            ["f2", a]
+        ])
+    ],
+    [
+        new sol.ArrayType(a),
+        new sol.ArrayType(new sol.PointerType(new sol.ArrayType(b), sol.DataLocation.Memory)),
+        new sol.ArrayType(new sol.PointerType(new sol.ArrayType(b), sol.DataLocation.Memory))
+    ],
+    [
+        new ExpStructType("a", [
+            ["a", a],
+            ["b", new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory)]
+        ]),
+        new ExpStructType("a", [
+            ["a", new sol.PointerType(new sol.ArrayType(b), sol.DataLocation.Memory)],
+            ["b", b]
+        ]),
+        new ExpStructType("a", [
+            [
+                "a",
+                new sol.PointerType(
+                    new sol.ArrayType(
+                        new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory)
+                    ),
+                    sol.DataLocation.Memory
+                )
+            ],
+            ["b", new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory)]
+        ])
+    ],
+    [
+        new TUnion([uint256, uint8]),
+        uint8,
+        uint8
+    ],
+    [
+        new TUnion([uint256, new sol.PointerType(new sol.ArrayType(a, 5n), sol.DataLocation.Memory)]),
+        new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory),
+        new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory),
+    ]
+];
+
+const concretizeTests: Array<[sol.TypeNode[], sol.TypeNode[], sol.TypeNode[] | undefined]> = [
+    [
+        [uint256, uint8],
+        [sol.types.address, sol.types.bool],
+        [uint256, uint8]
+    ],
+    [[uint256, new TOptional(uint8)], [uint256], [uint256]],
+    [
+        [uint256, new TOptional(uint8)],
+        [uint256, uint8],
+        [uint256, uint8]
+    ],
+    [[uint256, new TOptional(new TUnion([uint8, uint256]))], [uint256, sol.types.bool], undefined],
+    [[uint256, uint8], [uint256], undefined],
+    [
+        [new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory), a],
+        [new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Memory), uint256],
+        [new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Memory), uint8]
+    ],
+    [
+        [uint256, new TRest()],
+        [uint256, uint8, uint256],
+        [uint256, uint8, uint256]
+    ],
+    [
+        [uint256, new TRest()],
+        [uint256],
+        [uint256]
+    ],
+    [
+        [new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory), a, new TRest()],
+        [new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Memory), uint256, uint8],
+        [new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Memory), uint8, uint8]
+    ],
+];
+
+function ppTypes(ts: sol.TypeNode[]): string {
+    return ts.map((t) => t.pp()).join(", ");
+}
+
+describe("Polymorphism tests", () => {
+    describe("Unification tests", () => {
+        for (const [t1, t2, expectedRes] of unificationSamples) {
+            it(`Unify ${t1.pp()} and ${t2.pp()} ${expectedRes ? "succeeds" : "fails"}`, () => {
+                const res = unify(t1, t2, new Map());
+                expect(res).toEqual(expectedRes);
+            });
+        }
+    });
+
+    describe("Substitution tests", () => {
+        for (const [t1, t2, expectedRes] of substSamples) {
+            it(`After unification ${t1.pp()} and ${t2.pp()} become ${expectedRes.pp()}`, () => {
+                const subst = new Map();
+                const t = unify(t1, t2, subst);
+                expect(t).toEqual(true);
+                const res = substitute(t1, subst);
+                expect(res.pp()).toEqual(substitute(t2, subst).pp());
+                expect(res.pp()).toEqual(expectedRes.pp());
+            });
+        }
+    });
+
+    describe("Concretization tests", () => {
+        for (const [t1, t2, expected] of concretizeTests) {
+            it(`Concretizing ${ppTypes(t1)} and ${ppTypes(t2)} become ${expected !== undefined ? ppTypes(expected) : "<exception>"}`, () => {
+                if (expected !== undefined) {
+                    const [res] = concretize(t1, t2);
+                    expect(ppTypes(res)).toEqual(ppTypes(expected));
+                } else {
+                    expect(() => concretize(t1, t2)).toThrow();
+                }
+            });
+        }
+    });
+});

--- a/test/unit/poly.spec.ts
+++ b/test/unit/poly.spec.ts
@@ -99,7 +99,11 @@ const unificationSamples: Array<[sol.TypeNode, sol.TypeNode, boolean]> = [
     [new TUnion([uint256, uint8]), sol.types.address, false],
     [new sol.TupleType([a]), new sol.TupleType([uint256, uint8]), false],
     [new sol.ArrayType(a), new sol.ArrayType(uint8, 5n), false],
-    [new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory), new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Storage), false]
+    [
+        new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory),
+        new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Storage),
+        false
+    ]
 ];
 
 const substSamples: Array<[sol.TypeNode, sol.TypeNode, sol.TypeNode]> = [
@@ -159,15 +163,14 @@ const substSamples: Array<[sol.TypeNode, sol.TypeNode, sol.TypeNode]> = [
             ["b", new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory)]
         ])
     ],
+    [new TUnion([uint256, uint8]), uint8, uint8],
     [
-        new TUnion([uint256, uint8]),
-        uint8,
-        uint8
-    ],
-    [
-        new TUnion([uint256, new sol.PointerType(new sol.ArrayType(a, 5n), sol.DataLocation.Memory)]),
+        new TUnion([
+            uint256,
+            new sol.PointerType(new sol.ArrayType(a, 5n), sol.DataLocation.Memory)
+        ]),
         new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory),
-        new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory),
+        new sol.PointerType(new sol.ArrayType(uint256, 5n), sol.DataLocation.Memory)
     ]
 ];
 
@@ -195,16 +198,12 @@ const concretizeTests: Array<[sol.TypeNode[], sol.TypeNode[], sol.TypeNode[] | u
         [uint256, uint8, uint256],
         [uint256, uint8, uint256]
     ],
-    [
-        [uint256, new TRest()],
-        [uint256],
-        [uint256]
-    ],
+    [[uint256, new TRest()], [uint256], [uint256]],
     [
         [new sol.PointerType(new sol.ArrayType(a), sol.DataLocation.Memory), a, new TRest()],
         [new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Memory), uint256, uint8],
         [new sol.PointerType(new sol.ArrayType(uint8), sol.DataLocation.Memory), uint8, uint8]
-    ],
+    ]
 ];
 
 function ppTypes(ts: sol.TypeNode[]): string {


### PR DESCRIPTION
This PR provides the scaffolding for builtins along with `array.push()` and `array.pop()` as proofs of concept.

Builtins are tricky mainly because they are polymorphic. For example one type we could assign to push is:
`(T[] storage, T) -> void`, where `T` is a type variable. (In practice we gave push `(T[] storage, U)` to since memory->storage ref type copies couldn't be done in the caller context as the storage location is not yet known).

This PR adds:

- polymoprhic types `TVar`, `TUnion`, `TOptional`, `TRest` along with the following functions:
      - `uinfy(t1: TypeNode, t2: TypeNode, subst: TSubst)` computes a substitution from type vars and union types that transforms t1 into t2
      - `substitute(t: TypeNode, subst: TSubst): TypeNode` substitues all type vars-like types in `t` and returns the concrete type
      - `concretize(t1s: TypeNode[], t2s: TypeNode[]): TypeNode[]` - given a list of polymorphic formal argument types for a builtin, and a list of types of actual arguments, attempt to concretize the polymorphic formal types. Note that if a type is already concrete it is not exactly matched with the actual argument type.

- adds support for calling `BuiltinFunction` in the same code paths (`Interp._execCall`) as all other functions
- sets up the lexical scopes to builtins to only contain other builtin functions.